### PR TITLE
[BUG] (#28) 알림 시작/종료일시를 전체 기간으로 변경했을 때 반영되지 않는 문제 수정

### DIFF
--- a/src/repository/Model.js
+++ b/src/repository/Model.js
@@ -89,9 +89,17 @@ class Model {
       });
   }
 
-  update(id, model) {
-    return this.runQuery(collection => collection.updateOne({ _id: ObjectID(id) }, { $set: model }))
-      .then(result => ({ data: [{ _id: id }], count: result.result.nModified }))
+  update(id, model, unset) {
+    return this.updateWithQuery({ _id: ObjectID(id) }, model, unset);
+  }
+
+  updateWithQuery(query, model, unset) {
+    const option = { $set: model };
+    if (unset) {
+      option.$unset = unset;
+    }
+    return this.runQuery(collection => collection.findOneAndUpdate(query, option))
+      .then(result => ({ data: [{ _id: result.value._id.toHexString() }], count: 1 }))
       .catch((error) => {
         logger.error(error);
         throw new NotifierError(NotifierError.Types.DB, {}, error);

--- a/src/repository/Status.js
+++ b/src/repository/Status.js
@@ -63,8 +63,8 @@ class Status extends Model {
     });
   }
 
-  update(id, model) {
-    return super.update(id, model).then((result) => {
+  update(id, model, unset) {
+    return super.update(id, model, unset).then((result) => {
       cache.del('status');
       return result;
     });

--- a/src/router/api-router.js
+++ b/src/router/api-router.js
@@ -127,11 +127,15 @@ module.exports = [
     path: `${config.statusApiPrefix}/{statusId}`,
     handler: (request, reply) => {
       const status = Object.assign({}, request.payload);
-      if (status.startTime && status.endTime) {
-        status.startTime = new Date(Date.parse(status.startTime));
-        status.endTime = new Date(Date.parse(status.endTime));
+      let unset;
+      if (!status.startTime && !status.endTime) {
+        unset = { startTime: 1, endTime: 1 };
+      } else {
+        status.startTime = (status.startTime) ? new Date(Date.parse(status.startTime)) : undefined;
+        status.endTime = (status.endTime) ? new Date(Date.parse(status.endTime)) : undefined;
       }
-      Status.update(request.params.statusId, status)
+
+      Status.update(request.params.statusId, status, unset)
         .then(result => reply(result))
         .catch(err => reply(err));
     },

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -102,6 +102,16 @@ const statusDataToBeUpdated = {
   app_sem_version: '>=4.5.6 || =1.2.3',
   start_time: moment().format(),
   end_time: moment().add(3, 'hours').format(),
+  url: 'http://127.0.0.1',
+};
+
+const statusDataToBeUpdatedForAllDay = {
+  type: 'routineInspection',
+  device_types: ['paper', 'ios'],
+  contents: 'routineInspection-added1-updated1',
+  is_activated: true,
+  device_sem_version: '>=1.2.3',
+  app_sem_version: '>=4.5.6 || =1.2.3',
 };
 
 describe('status', () => {
@@ -214,8 +224,35 @@ describe('status', () => {
             expect(result[0].deviceTypes).toEqual(statusDataToBeUpdated.device_types);
             expect(result[0].deviceSemVersion).toBe(statusDataToBeUpdated.device_sem_version);
             expect(result[0].appSemVersion).toBe(statusDataToBeUpdated.app_sem_version);
+            expect(result[0].url).toBe(statusDataToBeUpdated.url);
             expect(moment(result[0].startTime).format()).toBe(statusDataToBeUpdated.start_time);
             expect(moment(result[0].endTime).format()).toBe(statusDataToBeUpdated.end_time);
+          });
+      });
+    });
+
+    test('update status for all day', () => {
+      return serverPromise.then((server) => {
+        return server.inject({
+          url: `${url}/${statusDataToBeAdded.id}`,
+          method: 'PUT',
+          payload: statusDataToBeUpdatedForAllDay,
+          credentials: { username: 'admin' },
+        }).then((response) => {
+          expect(response.statusCode).toBe(200);
+          const payload = JSON.parse(response.payload);
+          expect(payload.success).toBe(true);
+          expect(payload.data[0].id).toBe(statusDataToBeAdded.id);
+          return payload;
+        }).then(payload => Status.find({ _id: payload.data[0].id }))
+          .then((result) => {
+            expect(result.length).toBe(1);
+            expect(result[0].contents).toBe(statusDataToBeUpdatedForAllDay.contents);
+            expect(result[0].deviceTypes).toEqual(statusDataToBeUpdatedForAllDay.device_types);
+            expect(result[0].deviceSemVersion).toBe(statusDataToBeUpdatedForAllDay.device_sem_version);
+            expect(result[0].appSemVersion).toBe(statusDataToBeUpdatedForAllDay.app_sem_version);
+            expect(result[0].startTime).toBe(undefined);
+            expect(result[0].endTime).toBe(undefined);
           });
       });
     });


### PR DESCRIPTION
- 테스트케이스 추가 및 업데이트
- MongoDB의 update 함수가 의도한 바와 달리 document 전체를 교체하는 것이 아니라 필드 별로 업데이트 하기 때문에 생긴 문제