### PR TITLE
[BUGFIX] 새 알림 등록시 타입을 변경하고 알림 내용을 수정하지 않으면 저장했을 때 디폴트 타입의 템플릿 내용으로 변경…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /public/
 webpack-assets.json
 /coverage/
+/dist/

--- a/src/component/RichEditor.jsx
+++ b/src/component/RichEditor.jsx
@@ -85,7 +85,7 @@ class RichEditor extends React.Component {
     } else {
       editorState = EditorState.createEmpty();
     }
-    this.setState({ editorState });
+    this.onChange(editorState);
   }
 
   render() {

--- a/tests/router/status-type-api-router.test.js
+++ b/tests/router/status-type-api-router.test.js
@@ -13,7 +13,7 @@ const StatusType = require('../../src/repository/StatusType');
 const config = require('../../src/config/server.config.js');
 
 jest.dontMock('console');
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;  // 10s
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;  // 20s
 
 const serverPromise = Server.start();
 


### PR DESCRIPTION
…되는 문제 수정

- 알림타입 변경 이벤트가 발생할 때 저장 기능을 위해 내부적으로 관리하는 `state.contents`의 내용이 변경되지 않고 직접 타이핑으로 입력할 때만 내용이 변경되는 문제가 있었음